### PR TITLE
Fix to work with 1.8.7 again.

### DIFF
--- a/kumade.gemspec
+++ b/kumade.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('heroku', '~> 2.0')
   s.add_dependency('thor', '~> 0.14')
+  s.add_dependency('rake', '~> 0.8.7')
 
   s.add_development_dependency('rake', '~> 0.8.7')
   s.add_development_dependency('rspec', '~> 2.6.0')

--- a/lib/kumade/version.rb
+++ b/lib/kumade/version.rb
@@ -1,3 +1,3 @@
 module Kumade
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/spec/kumade/deployer_spec.rb
+++ b/spec/kumade/deployer_spec.rb
@@ -291,6 +291,7 @@ end
 
 describe Kumade::Deployer, "#invoke_custom_task" do
   before do
+    subject.stub(:say)
     Rake::Task.stub(:[] => task)
   end
 


### PR DESCRIPTION
The Readme says that is was tested using 1.8.7 but it isn't true. 

I really don't agree with release a new gem version when travis-ci is not green.
