### PR TITLE
Changing kumade to allow permanent configuration of cedar stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ The default is to deploy to staging:
 
 ## Does it support the Cedar stack?
 
-Yes. To indicate that a particular app is using Cedar, run with the -c flag:
+Yes. To indicate that a particular environment is using Cedar, configure environment stack on your git. Example:
 
-    bundle exec kumade bamboo -c
+    git config --add my-environment.stack "cedar"
 
 ## Sample Output
 

--- a/lib/kumade/runner.rb
+++ b/lib/kumade/runner.rb
@@ -19,7 +19,7 @@ module Kumade
         @out.puts "==> In Pretend Mode"
       end
       @out.puts "==> Deploying to: #{environment}"
-      Deployer.new(environment, pretending?, @options[:cedar]).deploy
+      Deployer.new(environment, pretending?, cedar?).deploy
       @out.puts "==> Deployed to: #{environment}"
     end
 
@@ -30,10 +30,6 @@ module Kumade
 
         opts.on("-p", "--pretend", "Pretend mode: print what kumade would do") do |p|
           options[:pretend] = p
-        end
-
-        opts.on("-c", "--cedar", "Use this if your app is on cedar") do |cedar|
-          options[:cedar] = cedar
         end
 
         opts.on_tail('-v', '--version', 'Show version') do
@@ -52,6 +48,10 @@ module Kumade
 
     def self.pretending?
       @options[:pretend]
+    end
+
+    def self.cedar?
+      `git config --get #{environment}.stack`.include?("cedar")
     end
   end
 end

--- a/spec/kumade/runner_spec.rb
+++ b/spec/kumade/runner_spec.rb
@@ -25,15 +25,23 @@ describe Kumade::Runner do
 
     subject.run([environment], out)
   end
-
-  %w(-c --cedar).each do |cedar_arg|
-    it "uses cedar when run with #{cedar_arg}" do
-      deployer = double("deployer").as_null_object
-      Kumade::Deployer.should_receive(:new).
-        with(anything, anything, true).
-        and_return(deployer)
-
-      subject.run([environment, cedar_arg], out)
-    end
+  
+  it "should use cedar if git config environment stack is cedar" do
+    `git config --add my-environment.stack "cedar"`
+    deployer = double("deployer").as_null_object
+    Kumade::Deployer.should_receive(:new).
+      with(anything, anything, true).
+      and_return(deployer)
+    subject.run([environment], out)
+    `git config --unset my-environment.stack "cedar"`
+  end
+  
+  it "should not cedar if git config environment stack is defined" do
+    `git config --unset my-environment.stack "cedar"`
+    deployer = double("deployer").as_null_object
+    Kumade::Deployer.should_receive(:new).
+      with(anything, anything, false).
+      and_return(deployer)
+    subject.run([environment], out)
   end
 end

--- a/spec/kumade/runner_spec.rb
+++ b/spec/kumade/runner_spec.rb
@@ -36,7 +36,7 @@ describe Kumade::Runner do
     `git config --unset my-environment.stack "cedar"`
   end
   
-  it "should not cedar if git config environment stack is defined" do
+  it "should not cedar if git config environment stack isn't defined" do
     `git config --unset my-environment.stack "cedar"`
     deployer = double("deployer").as_null_object
     Kumade::Deployer.should_receive(:new).


### PR DESCRIPTION
I think that using "-c" to use 'cedar stack' is too boring. I want to keep it configured and just run "kumade environment".

I changed the kumade runner to allow it.
