### PR TITLE
Adds "--clear_cache" option to clear the Rails cache after migration

### DIFF
--- a/features/kumade_executable.feature
+++ b/features/kumade_executable.feature
@@ -32,6 +32,11 @@ Feature: Kumade executable
       ==> Deployed to: pretend-staging
       """
     But the output should not contain "==> Packaged assets with More"
+    And the output should not contain "==> Cache Cleared"
+
+  Scenario: Clears the Rails cache if requested
+    When I run kumade with "-p --clear_cache"
+    Then the output should contain "==> Cache Cleared"
 
   Scenario: Default environment is staging
     When I run kumade with "-p"

--- a/lib/kumade/runner.rb
+++ b/lib/kumade/runner.rb
@@ -19,7 +19,7 @@ module Kumade
         @out.puts "==> In Pretend Mode"
       end
       @out.puts "==> Deploying to: #{environment}"
-      Deployer.new(environment, pretending?, @options[:cedar]).deploy
+      Deployer.new(environment, pretending?, @options[:cedar], clearing_cache?).deploy
       @out.puts "==> Deployed to: #{environment}"
     end
 
@@ -34,6 +34,10 @@ module Kumade
 
         opts.on("-c", "--cedar", "Use this if your app is on cedar") do |cedar|
           options[:cedar] = cedar
+        end
+
+        opts.on("", "--clear_cache", "Clear the Rails cache after deployment") do |clear_cache|
+          options[:clear_cache] = clear_cache
         end
 
         opts.on_tail('-v', '--version', 'Show version') do
@@ -52,6 +56,10 @@ module Kumade
 
     def self.pretending?
       @options[:pretend]
+    end
+
+    def self.clearing_cache?
+      @options[:clear_cache]
     end
   end
 end

--- a/spec/kumade/deployer_spec.rb
+++ b/spec/kumade/deployer_spec.rb
@@ -100,7 +100,7 @@ describe Kumade::Deployer, "#sync_heroku" do
   let(:environment) { 'my-env' }
   subject { Kumade::Deployer.new(environment) }
   before { subject.stub(:say) }
-  
+
   context "when deploy branch exists" do
     it "should calls `git push -f`" do
       subject.stub(:branch_exist?).with("deploy").and_return(true)
@@ -481,6 +481,25 @@ describe Kumade::Deployer, "#heroku_migrate" do
     subject.should_receive(:success).with("Migrated #{app_name}")
 
     subject.heroku_migrate
+  end
+end
+
+describe Kumade::Deployer, "#heroku_clear_cache" do
+  let(:environment){ 'staging' }
+  let(:app_name){ 'sushi' }
+
+  before do
+    subject { Kumade::Deployer.new('staging', false, false, true) }
+    force_add_heroku_remote(environment, app_name)
+  end
+
+  it "runs 'console \"Rails.cache.clear\"'" do
+    subject.stub(:run => true)
+    subject.should_receive(:heroku_command).
+      with('console "Rails.cache.clear"')
+    subject.should_receive(:success).with("Cache Cleared")
+
+    subject.heroku_clear_cache
   end
 end
 

--- a/spec/kumade/runner_spec.rb
+++ b/spec/kumade/runner_spec.rb
@@ -14,6 +14,13 @@ describe Kumade::Runner do
     end
   end
 
+  it "clears the Rails cache when run with --clear_cache" do
+    subject.stub(:deploy)
+
+    subject.run([environment, "--clear_cache"], out)
+    subject.clearing_cache?.should be_true
+  end
+
   it "defaults to staging" do
     subject.stub(:deploy)
     subject.run([], out)
@@ -30,7 +37,7 @@ describe Kumade::Runner do
     it "uses cedar when run with #{cedar_arg}" do
       deployer = double("deployer").as_null_object
       Kumade::Deployer.should_receive(:new).
-        with(anything, anything, true).
+        with(anything, anything, true, anything).
         and_return(deployer)
 
       subject.run([environment, cedar_arg], out)


### PR DESCRIPTION
I frequently need to clear my cache after a deployment. This adds a "--clear_cache" option to run "heroku console 'Rails.cache.clear' ".  I did not assign a single letter switch since "-c" was already taken and I couldn't think of a decent alternative.

This is the first time I've ever used Cucumber, so constructive criticism welcome (and expected). :)
