### PR TITLE
Run silently until an error occurs.

### DIFF
--- a/lib/kumade.rb
+++ b/lib/kumade.rb
@@ -1,11 +1,13 @@
 require 'rake'
 require 'thor'
+require 'stringio'
 
 require 'kumade/base'
 require 'kumade/git'
 require 'kumade/deployer'
 require 'kumade/runner'
 require 'kumade/railtie'
+require 'kumade/deployment_error'
 
 module Kumade
 end

--- a/lib/kumade/base.rb
+++ b/lib/kumade/base.rb
@@ -20,7 +20,7 @@ module Kumade
     
     def error(message)
       say("==> ! #{message}", :red)
-      exit 1
+      raise Kumade::DeploymentError.new(message)
     end
     
     def success(message)

--- a/lib/kumade/deployment_error.rb
+++ b/lib/kumade/deployment_error.rb
@@ -1,0 +1,4 @@
+module Kumade
+  class DeploymentError < StandardError
+  end
+end

--- a/spec/kumade/base_spec.rb
+++ b/spec/kumade/base_spec.rb
@@ -10,4 +10,9 @@ describe Kumade::Base, "#error" do
   it "exists" do
     subject.should respond_to(:error)
   end
+
+  it "prints its message and raises its message" do
+    subject.should_receive(:say).with("==> ! I'm an error!", :red)
+    lambda{ subject.error("I'm an error!") }.should raise_error(Kumade::DeploymentError)
+  end
 end

--- a/spec/kumade/deployer_spec.rb
+++ b/spec/kumade/deployer_spec.rb
@@ -453,4 +453,9 @@ describe Kumade::Deployer, "#post_deploy" do
     git_mock.should_receive(:delete).with('deploy', 'master')
     subject.post_deploy
   end
+
+  it "prints its message and raises its message" do
+    subject.should_receive(:say).with("==> ! I'm an error!", :red)
+    lambda{ subject.error("I'm an error!") }.should raise_error(Kumade::DeploymentError)
+  end
 end

--- a/spec/kumade/runner_spec.rb
+++ b/spec/kumade/runner_spec.rb
@@ -37,3 +37,40 @@ describe Kumade::Runner do
     end
   end
 end
+
+describe Kumade::Runner do
+  it 'does not let anything get printed' do
+    stdout = $stdout
+    stdout.should_not_receive(:print)
+    output = StringIO.new
+
+    Kumade::Runner.swapping_stdout_for(output) do
+      $stdout.puts "Hello, you can't see me."
+    end
+
+    output.rewind
+    output.read.should == "Hello, you can't see me.\n"
+  end
+
+  it 'dumps the output stash to real stdout when an error happens' do
+    stdout = $stdout
+    stdout.should_receive(:print)
+    output = StringIO.new
+
+    Kumade::Runner.swapping_stdout_for(output) do
+      $stdout.puts "Hello, you can see me!"
+      raise Kumade::DeploymentError.new("error")
+    end
+  end
+
+  it 'prints everything in pretend mode' do
+    stdout = $stdout
+    stdout.should_receive(:puts)
+    output = StringIO.new
+    Kumade::Runner.should_receive(:pretending?).and_return(true)
+
+    Kumade::Runner.swapping_stdout_for(output) do
+      $stdout.puts "Hello, you can see me!"
+    end
+  end
+end


### PR DESCRIPTION
This will make kumade silent until something goes wrong, then it will spit out the whole output history.
