### PR TITLE
Heroku#cedar? check was totally broken.  Fixed.

### DIFF
--- a/lib/kumade/command_line.rb
+++ b/lib/kumade/command_line.rb
@@ -2,6 +2,8 @@ require 'cocaine'
 
 module Kumade
   class CommandLine
+    attr_reader :last_command_output
+
     def initialize(command_to_run)
       @command_line = Cocaine::CommandLine.new(command_to_run)
     end
@@ -17,7 +19,7 @@ module Kumade
 
     def run
       begin
-        @command_line.run
+        @last_command_output = @command_line.run
         true
       rescue Cocaine::ExitStatusError, Cocaine::CommandNotFoundError
         false

--- a/lib/kumade/heroku.rb
+++ b/lib/kumade/heroku.rb
@@ -35,7 +35,8 @@ module Kumade
 
       command_line = CommandLine.new("bundle exec heroku stack --remote #{Kumade.configuration.environment}")
 
-      @cedar = command_line.run_or_error.split("\n").grep(/\*/).any? do |line|
+      command_line.run_or_error "Error while checking Heroku stack"
+      @cedar = command_line.last_command_output.split("\n").grep(/\*/).any? do |line|
         line.include?("cedar")
       end
     end

--- a/spec/kumade/command_line_spec.rb
+++ b/spec/kumade/command_line_spec.rb
@@ -88,6 +88,15 @@ describe Kumade::CommandLine, "#run_with_status", :with_mock_outputter do
 end
 
 describe Kumade::CommandLine, "#run", :with_mock_outputter do
+
+  it "saves the output of the most recent command to the reader :last_command_output" do
+    (cmd_line = Kumade::CommandLine.new("echo 'test'")).run
+    cmd_line.last_command_output.should == "test\n"
+
+    (cmd_line = Kumade::CommandLine.new("echo 'yo'")).run
+    cmd_line.last_command_output.should == "yo\n"
+  end
+
   context "when successful" do
     subject { Kumade::CommandLine.new("echo") }
 

--- a/spec/support/heroku.rb
+++ b/spec/support/heroku.rb
@@ -6,7 +6,8 @@ shared_context "when on Cedar" do
       with("bundle exec heroku stack --remote staging").
       returns(command_line)
 
-    command_line.expects(:run_or_error).returns(%{
+    command_line.expects(:run_or_error).returns(true)
+    command_line.expects(:last_command_output).returns(%{
   aspen-mri-1.8.6
   bamboo-mri-1.9.2
   bamboo-ree-1.8.7
@@ -23,7 +24,8 @@ shared_context "when not on Cedar" do
       with("bundle exec heroku stack --remote staging").
       returns(command_line)
 
-    command_line.expects(:run_or_error).returns(%{
+    command_line.expects(:run_or_error).returns(true)
+    command_line.expects(:last_command_output).returns(%{
   aspen-mri-1.8.6
 * bamboo-mri-1.9.2
   bamboo-ree-1.8.7


### PR DESCRIPTION
Not sure how kumade was even working!  `Heroku#cedar?`called `CommandLine#run_or_error`, and tried to `#split` it's output.  The problem was that `#run_or_error` was directly returning `#run`'s output, which was always either `true` or `false`, and is of course **not** a string and therefore **cannot** be split.  The heroku shared context was mocking `#run_or_error` to return the output of the actual command, which is not what was being returned from `#run`.

Anyways, fixed now :)
