### PR TITLE
Kumade now restarts Heroku app after db:migrate.

### DIFF
--- a/lib/kumade/deployer.rb
+++ b/lib/kumade/deployer.rb
@@ -18,6 +18,7 @@ module Kumade
         pre_deploy
         heroku.sync
         heroku.migrate_database
+        heroku.restart_app
       rescue => deploying_error
         Kumade.configuration.outputter.error("#{deploying_error.class}: #{deploying_error.message}")
       ensure

--- a/lib/kumade/heroku.rb
+++ b/lib/kumade/heroku.rb
@@ -20,6 +20,11 @@ module Kumade
       Kumade.configuration.outputter.success("Migrated #{Kumade.configuration.environment}")
     end
 
+    def restart_app
+      heroku("restart") unless Kumade.configuration.pretending?
+      Kumade.configuration.outputter.success("Restarted #{Kumade.configuration.environment}")
+    end
+
     def delete_deploy_branch
       git.delete(DEPLOY_BRANCH, @branch)
     end

--- a/spec/kumade/deployer_spec.rb
+++ b/spec/kumade/deployer_spec.rb
@@ -23,6 +23,7 @@ describe Kumade::Deployer, "#deploy", :with_mock_outputter do
     subject.expects(:pre_deploy)
     subject.heroku.expects(:sync)
     subject.heroku.expects(:migrate_database)
+    subject.heroku.expects(:restart_app)
     subject.expects(:post_deploy)
 
     subject.deploy

--- a/spec/kumade/heroku_spec.rb
+++ b/spec/kumade/heroku_spec.rb
@@ -56,6 +56,39 @@ describe Kumade::Heroku, "#migrate_database", :with_mock_outputter do
   end
 end
 
+describe Kumade::Heroku, "#restart_app", :with_mock_outputter do
+  let(:environment) { 'staging' }
+
+  before do
+    subject.stubs(:heroku)
+    force_add_heroku_remote(environment)
+  end
+
+  it "runs the heroku restart command" do
+    subject.restart_app
+
+    subject.should have_received(:heroku).with("restart")
+  end
+
+  it "prints a message" do
+    subject.restart_app
+
+    Kumade.configuration.outputter.should have_received(:success).with(regexp_matches(/Restarted #{environment}/))
+  end
+
+  context "when pretending" do
+    before do
+      Kumade.configuration.pretending = true
+    end
+
+    it "does not run the command" do
+      subject.restart_app
+
+      subject.should have_received(:heroku).never
+    end
+  end
+end
+
 describe Kumade::Heroku, "#heroku", :with_mock_outputter do
   let(:command_instance) { stub("Kumade::CommandLine instance", :run_or_error => true) }
 


### PR DESCRIPTION
See issue #68.
