### PR TITLE
Git#push when remote does not exist returns silently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp/
 *.sw[op]
 .rvmrc
 coverage/
+tags

--- a/features/git.feature
+++ b/features/git.feature
@@ -1,4 +1,4 @@
-@creates-remote @disable-bundler
+@disable-bundler
 Feature: Git cleanliness
   As a user
   I want Kumade to check if git is clean before deploying

--- a/features/git.feature
+++ b/features/git.feature
@@ -17,3 +17,8 @@ Feature: Git cleanliness
     When I modify a tracked file
     And I run kumade with "pretend-staging"
     Then the output should contain "==> ! Cannot deploy: repo is not clean"
+
+  Scenario: Git repo is always clean when pretending
+    Given a dirty repo
+    When I run kumade with "pretend-staging -p"
+    Then the output should contain "==> Git repo is clean"

--- a/features/git.feature
+++ b/features/git.feature
@@ -1,4 +1,3 @@
-@disable-bundler
 Feature: Git cleanliness
   As a user
   I want Kumade to check if git is clean before deploying

--- a/features/git.feature
+++ b/features/git.feature
@@ -1,0 +1,19 @@
+@creates-remote @disable-bundler
+Feature: Git cleanliness
+  As a user
+  I want Kumade to check if git is clean before deploying
+  So that I don't accidentally leave leave local changes behind
+
+  Background:
+    Given a directory set up for kumade
+    When I create a Heroku remote named "pretend-staging"
+
+  Scenario: Git is clean if there are untracked files
+    When I create an untracked file
+    And I run kumade with "pretend-staging"
+    Then the output should not contain "==> ! Cannot deploy: repo is not clean"
+
+  Scenario: Git is not clean if a tracked file is modified
+    When I modify a tracked file
+    And I run kumade with "pretend-staging"
+    Then the output should contain "==> ! Cannot deploy: repo is not clean"

--- a/features/jammit.feature
+++ b/features/jammit.feature
@@ -1,0 +1,31 @@
+@creates-remote @disable-bundler
+Feature: Jammit
+  As a user
+  I want Kumade to auto-package with Jammit
+  So that I don't have to remember to package assets
+
+  Background:
+    Given a directory named "executable"
+    And I cd to "executable"
+    And I set up the Gemfile with kumade
+    And I add "jammit" to the Gemfile
+    And I bundle
+    When I set up a git repo
+    And I create a Heroku remote named "pretend-staging"
+
+  Scenario: Jammit packager runs if Jammit is installed
+    When I run kumade with "pretend-staging"
+    Then the output from "bundle exec kumade pretend-staging" should contain "==> ! Error: Jammit::MissingConfiguration"
+
+  Scenario: Run custom task before jammit
+    Given I write to "Rakefile" with:
+      """
+      namespace :kumade do
+        task :before_asset_compilation do
+          puts 'Hi!'
+        end
+      end
+      """
+    When I run kumade with "pretend-staging -p"
+    Then the output should contain "kumade:before_asset_compilation"
+    And the output should contain "==> Packaged with Kumade::JammitPackager"

--- a/features/jammit.feature
+++ b/features/jammit.feature
@@ -1,4 +1,4 @@
-@slow @disable-bundler
+@slow
 Feature: Jammit
   As a user
   I want Kumade to auto-package with Jammit

--- a/features/jammit.feature
+++ b/features/jammit.feature
@@ -1,4 +1,4 @@
-@slow @creates-remote @disable-bundler
+@slow @disable-bundler
 Feature: Jammit
   As a user
   I want Kumade to auto-package with Jammit

--- a/features/jammit.feature
+++ b/features/jammit.feature
@@ -1,31 +1,20 @@
-@creates-remote @disable-bundler
+@slow @creates-remote @disable-bundler
 Feature: Jammit
   As a user
   I want Kumade to auto-package with Jammit
   So that I don't have to remember to package assets
 
   Background:
-    Given a directory named "executable"
-    And I cd to "executable"
-    And I set up the Gemfile with kumade
-    And I add "jammit" to the Gemfile
-    And I bundle
-    When I set up a git repo
-    And I create a Heroku remote named "pretend-staging"
+    Given a new Rails application with Kumade and Jammit
+    When I configure my Rails app for Jammit
+    And I create a Heroku remote named "staging"
 
   Scenario: Jammit packager runs if Jammit is installed
-    When I run kumade with "pretend-staging"
-    Then the output from "bundle exec kumade pretend-staging" should contain "==> ! Error: Jammit::MissingConfiguration"
+    When I run kumade
+    Then the output should contain "==> Packaged with Kumade::JammitPackager"
 
   Scenario: Run custom task before jammit
-    Given I write to "Rakefile" with:
-      """
-      namespace :kumade do
-        task :before_asset_compilation do
-          puts 'Hi!'
-        end
-      end
-      """
-    When I run kumade with "pretend-staging -p"
+    When I add a pre-compilation rake task that prints "Hi!"
+    And I run kumade
     Then the output should contain "kumade:before_asset_compilation"
-    And the output should contain "==> Packaged with Kumade::JammitPackager"
+    And the output should contain "Hi!"

--- a/features/kumade_executable.feature
+++ b/features/kumade_executable.feature
@@ -61,21 +61,3 @@ Feature: Kumade executable
       ==> Restarted pretend-staging
       ==> Deployed to: pretend-staging
       """
-
-  Scenario: Git is clean if there are untracked files
-    Given I write to "new-file" with:
-      """
-      clean
-      """
-    When I run kumade with "pretend-staging"
-    Then the output from "bundle exec kumade pretend-staging" should not contain "==> ! Cannot deploy: repo is not clean"
-
-  Scenario: Git is not clean if a tracked file is modified
-    Given I write to "new-file" with:
-      """
-      clean
-      """
-    And I commit everything in the current repo
-    When I append to "new-file" with "dirty it up"
-    And I run kumade with "pretend-staging"
-    Then the output from "bundle exec kumade pretend-staging" should contain "==> ! Cannot deploy: repo is not clean"

--- a/features/kumade_executable.feature
+++ b/features/kumade_executable.feature
@@ -1,4 +1,4 @@
-@slow @creates-remote @disable-bundler
+@slow @disable-bundler
 Feature: Kumade executable
   As a user
   I want to be able to use the kumade executable

--- a/features/kumade_executable.feature
+++ b/features/kumade_executable.feature
@@ -1,4 +1,4 @@
-@slow @disable-bundler
+@slow
 Feature: Kumade executable
   As a user
   I want to be able to use the kumade executable

--- a/features/kumade_executable.feature
+++ b/features/kumade_executable.feature
@@ -79,20 +79,3 @@ Feature: Kumade executable
     When I append to "new-file" with "dirty it up"
     And I run kumade with "pretend-staging"
     Then the output from "bundle exec kumade pretend-staging" should contain "==> ! Cannot deploy: repo is not clean"
-
-  Scenario: Jammit packager runs if Jammit is installed
-    When I run kumade with "pretend-staging"
-    Then the output from "bundle exec kumade pretend-staging" should contain "==> ! Error: Jammit::MissingConfiguration"
-
-  Scenario: Run custom task before jammit
-    Given I write to "Rakefile" with:
-      """
-      namespace :kumade do
-        task :before_asset_compilation do
-          puts 'Hi!'
-        end
-      end
-      """
-    When I run kumade with "pretend-staging -p"
-    Then the output should contain "kumade:before_asset_compilation"
-    And the output should contain "==> Packaged with Kumade::JammitPackager"

--- a/features/kumade_executable.feature
+++ b/features/kumade_executable.feature
@@ -36,7 +36,7 @@ Feature: Kumade executable
     When I run kumade with "-p"
     Then the output should contain "==> Deployed to: staging"
 
-  Scenario: Can deploy to arbitrary environment
+  Scenario: Deploying to an arbitrary environment fails
     When I run kumade with "bamboo"
     Then the output should contain "==> Deploying to: bamboo"
     And the output should match /Cannot deploy: /
@@ -45,19 +45,8 @@ Feature: Kumade executable
     When I run kumade with "bad-remote"
     Then the output should match /==> ! Cannot deploy: "bad-remote" remote does not point to Heroku/
 
-  Scenario: Deploy from another branch
+  Scenario: Deploy from a branch that isn't "master"
     When I run `git checkout -b new_branch`
     And I run kumade with "pretend-staging -p"
-    Then the output should contain:
-      """
-      ==> Git repo is clean
-      ==> Packaged with Kumade::JammitPackager
-              git push origin new_branch
-      ==> Pushed new_branch -> origin
-              git branch deploy >/dev/null
-              git push -f pretend-staging deploy:master
-      ==> Pushed deploy:master -> pretend-staging
-      ==> Migrated pretend-staging
-      ==> Restarted pretend-staging
-      ==> Deployed to: pretend-staging
-      """
+    Then the output should contain "==> Pushed new_branch -> origin"
+    And the output should contain "==> Deployed to: pretend-staging"

--- a/features/kumade_executable.feature
+++ b/features/kumade_executable.feature
@@ -5,13 +5,8 @@ Feature: Kumade executable
   So I can have a better experience than Rake provides
 
   Background:
-    Given a directory named "executable"
-    And I cd to "executable"
-    And I set up the Gemfile with kumade
-    And I add "jammit" to the Gemfile
-    And I bundle
-    When I set up a git repo
-    And I create a Heroku remote named "pretend-staging"
+    Given a new Rails application with Kumade and Jammit
+    When I create a Heroku remote named "pretend-staging"
     And I create a Heroku remote named "staging"
     And I create a non-Heroku remote named "bad-remote"
 
@@ -46,7 +41,7 @@ Feature: Kumade executable
     Then the output should match /==> ! Cannot deploy: "bad-remote" remote does not point to Heroku/
 
   Scenario: Deploy from a branch that isn't "master"
-    When I run `git checkout -b new_branch`
+    When I switch to the "new_branch" branch
     And I run kumade with "pretend-staging -p"
     Then the output should contain "==> Pushed new_branch -> origin"
     And the output should contain "==> Deployed to: pretend-staging"

--- a/features/kumade_without_jammit.feature
+++ b/features/kumade_without_jammit.feature
@@ -1,4 +1,4 @@
-@slow @disable-bundler
+@slow
 Feature: Kumade without jammit
 
   Background:

--- a/features/kumade_without_jammit.feature
+++ b/features/kumade_without_jammit.feature
@@ -1,4 +1,4 @@
-@slow @creates-remote @disable-bundler
+@slow @disable-bundler
 Feature: Kumade without jammit
 
   Background:

--- a/features/kumade_without_jammit.feature
+++ b/features/kumade_without_jammit.feature
@@ -2,12 +2,8 @@
 Feature: Kumade without jammit
 
   Background:
-    Given a directory named "executable"
-    And I cd to "executable"
-    And I set up the Gemfile with kumade
-    And I bundle
-    When I set up a git repo
-    And I create a Heroku remote named "pretend-staging"
+    Given a directory set up for kumade
+    When I create a Heroku remote named "pretend-staging"
 
   Scenario: Jammit packager does not run if Jammit is not installed
     When I run kumade with "pretend-staging"

--- a/features/kumade_without_jammit.feature
+++ b/features/kumade_without_jammit.feature
@@ -12,29 +12,3 @@ Feature: Kumade without jammit
   Scenario: Jammit packager does not run if Jammit is not installed
     When I run kumade with "pretend-staging"
     Then the output should not contain "==> ! Error: Jammit::MissingConfiguration"
-
-  Scenario: Run custom task if it exists
-    Given I write to "Rakefile" with:
-      """
-      namespace :kumade do
-        task :before_asset_compilation do
-          puts 'Hi!'
-        end
-      end
-      """
-    When I run kumade with "pretend-staging"
-    Then the output should contain "Running rake task: kumade:before_asset_compilation"
-    And the output should contain "Hi!"
-
-  Scenario: Don't run rake task in pretend mode
-    Given I write to "Rakefile" with:
-      """
-      namespace :kumade do
-        task :before_asset_compilation do
-          puts 'Hi!'
-        end
-      end
-      """
-    When I run kumade with "pretend-staging -p"
-    Then the output should contain "Running rake task: kumade:before_asset_compilation"
-    And the output should not contain "Hi!"

--- a/features/no_op_packager.feature
+++ b/features/no_op_packager.feature
@@ -1,0 +1,17 @@
+@slow @creates-remote @disable-bundler
+Feature: No-op packager
+  As a user
+  I want Kumade to gracefully handle occasions when I have no assets to package
+  So that I am not forced to package my assets
+
+  Background:
+    Given a new Rails app
+    When I create a Heroku remote for "my-app" named "staging"
+
+  Scenario: No-op packager runs in pretend mode if Jammit is not installed
+    When I run kumade with "staging -p"
+    Then the output should contain "==> Packaged with Kumade::NoopPackager"
+
+  Scenario: No-op packager runs in normal mode if Jammit is not installed
+    When I run kumade with "staging -v"
+    Then the output should contain "==> Packaged with Kumade::NoopPackager"

--- a/features/no_op_packager.feature
+++ b/features/no_op_packager.feature
@@ -5,13 +5,14 @@ Feature: No-op packager
   So that I am not forced to package my assets
 
   Background:
-    Given a new Rails app
-    When I create a Heroku remote for "my-app" named "staging"
+    Given a new Rails application with Kumade
+    When I create a Heroku remote named "staging"
 
   Scenario: No-op packager runs in pretend mode if Jammit is not installed
     When I run kumade with "staging -p"
     Then the output should contain "==> Packaged with Kumade::NoopPackager"
 
   Scenario: No-op packager runs in normal mode if Jammit is not installed
-    When I run kumade with "staging -v"
+    When I add the origin remote
+    And I run kumade
     Then the output should contain "==> Packaged with Kumade::NoopPackager"

--- a/features/no_op_packager.feature
+++ b/features/no_op_packager.feature
@@ -1,4 +1,4 @@
-@slow @creates-remote @disable-bundler
+@slow @disable-bundler
 Feature: No-op packager
   As a user
   I want Kumade to gracefully handle occasions when I have no assets to package

--- a/features/no_op_packager.feature
+++ b/features/no_op_packager.feature
@@ -1,4 +1,4 @@
-@slow @disable-bundler
+@slow
 Feature: No-op packager
   As a user
   I want Kumade to gracefully handle occasions when I have no assets to package

--- a/features/no_op_packager.feature
+++ b/features/no_op_packager.feature
@@ -8,11 +8,11 @@ Feature: No-op packager
     Given a new Rails application with Kumade
     When I create a Heroku remote named "staging"
 
-  Scenario: No-op packager runs in pretend mode if Jammit is not installed
+  Scenario: No-op packager does not run in pretend mode if Jammit is not installed
     When I run kumade with "staging -p"
-    Then the output should contain "==> Packaged with Kumade::NoopPackager"
+    Then the output should not contain "==> Packaged with Kumade::NoopPackager"
 
-  Scenario: No-op packager runs in normal mode if Jammit is not installed
+  Scenario: No-op packager does not run in normal mode if Jammit is not installed
     When I add the origin remote
     And I run kumade
-    Then the output should contain "==> Packaged with Kumade::NoopPackager"
+    Then the output should not contain "==> Packaged with Kumade::NoopPackager"

--- a/features/railtie.feature
+++ b/features/railtie.feature
@@ -3,7 +3,7 @@ Feature: Railtie
   I want Kumade to autoload Rake tasks for my Rails application
   So that I can integrate Kumade with other Rake tasks
 
-  @creates-remote @disable-bundler @slow
+  @disable-bundler @slow
   Scenario: Rake tasks are loaded
     Given a new Rails application with Kumade
     When I create a Heroku remote named "staging"

--- a/features/railtie.feature
+++ b/features/railtie.feature
@@ -3,7 +3,7 @@ Feature: Railtie
   I want Kumade to autoload Rake tasks for my Rails application
   So that I can integrate Kumade with other Rake tasks
 
-  @disable-bundler @slow
+  @slow
   Scenario: Rake tasks are loaded
     Given a new Rails application with Kumade
     When I create a Heroku remote named "staging"

--- a/features/rake_task_before_asset_compilation.feature
+++ b/features/rake_task_before_asset_compilation.feature
@@ -12,13 +12,12 @@ Feature: Rake task that runs before asset compilation
     Then the output should contain "kumade:before_asset_compilation"
     And the output should contain "Hi!"
 
-  Scenario: Custom task runs if Jammit is not installed
+  Scenario: Custom task runs does not run if Jammit is not installed
     Given a new Rails application with Kumade
     When I create a Heroku remote named "pretend-staging"
     And I add a pre-compilation rake task that prints "Hi!"
     And I run kumade with "pretend-staging"
-    Then the output should contain "kumade:before_asset_compilation"
-    And the output should contain "Hi!"
+    Then the output should not contain "kumade:before_asset_compilation"
 
   Scenario: Pre-asset compilation task does not run when pretending
     Given a new Rails application with Kumade and Jammit

--- a/features/rake_task_before_asset_compilation.feature
+++ b/features/rake_task_before_asset_compilation.feature
@@ -1,4 +1,4 @@
-@slow @disable-bundler
+@slow
 Feature: Rake task that runs before asset compilation
   As a user
   I want a Rake task that runs before packaging

--- a/features/rake_task_before_asset_compilation.feature
+++ b/features/rake_task_before_asset_compilation.feature
@@ -1,4 +1,4 @@
-@slow @creates-remote @disable-bundler
+@slow @disable-bundler
 Feature: Rake task that runs before asset compilation
   As a user
   I want a Rake task that runs before packaging

--- a/features/rake_task_before_asset_compilation.feature
+++ b/features/rake_task_before_asset_compilation.feature
@@ -1,0 +1,29 @@
+@slow @creates-remote @disable-bundler
+Feature: Rake task that runs before asset compilation
+  As a user
+  I want a Rake task that runs before packaging
+  So that I can hook into the packaging process
+
+  Scenario: Custom task runs if Jammit is installed
+    Given a new Rails application with Kumade and Jammit
+    When I create a Heroku remote named "pretend-staging"
+    And I add a pre-compilation rake task that prints "Hi!"
+    And I run kumade with "pretend-staging"
+    Then the output should contain "kumade:before_asset_compilation"
+    And the output should contain "Hi!"
+
+  Scenario: Custom task runs if Jammit is not installed
+    Given a new Rails application with Kumade
+    When I create a Heroku remote named "pretend-staging"
+    And I add a pre-compilation rake task that prints "Hi!"
+    And I run kumade with "pretend-staging"
+    Then the output should contain "kumade:before_asset_compilation"
+    And the output should contain "Hi!"
+
+  Scenario: Pre-asset compilation task does not run when pretending
+    Given a new Rails application with Kumade and Jammit
+    When I create a Heroku remote named "pretend-staging"
+    And I add a pre-compilation rake task that prints "Hi!"
+    And I run kumade with "pretend-staging -p"
+    Then the output should contain "kumade:before_asset_compilation"
+    But the output should not contain "Hi!"

--- a/features/step_definitions/bundler_steps.rb
+++ b/features/step_definitions/bundler_steps.rb
@@ -2,15 +2,6 @@ When /^I bundle$/ do
   run_bundler
 end
 
-When /^I rebundle$/ do
-  run_bundler
-  commit_everything_in_repo
-end
-
-Given /^an empty Gemfile$/ do
-  write_file('Gemfile', '')
-end
-
 When /^I set up the Gemfile with kumade$/ do
   add_kumade_to_gemfile
 end

--- a/features/step_definitions/bundler_steps.rb
+++ b/features/step_definitions/bundler_steps.rb
@@ -3,31 +3,18 @@ When /^I bundle$/ do
 end
 
 When /^I rebundle$/ do
-  steps %{
-    When I bundle
-    And I commit everything in the current repo
-  }
+  run_bundler
+  commit_everything_in_repo
 end
 
 Given /^an empty Gemfile$/ do
-  When %{I write to "Gemfile" with:}, ""
+  write_file('Gemfile', '')
 end
 
 When /^I set up the Gemfile with kumade$/ do
-  steps %{
-    When I write to "Gemfile" with:
-      """
-      gem 'kumade', :path => '../../..'
-      """
-  }
+  add_kumade_to_gemfile
 end
 
-When /^I add "([^"]+)" to the Gemfile$/ do |gem|
-  steps %{
-    When I append to "Gemfile" with:
-      """
-
-      gem '#{gem}'
-      """
-  }
+When /^I add "jammit" to the Gemfile$/ do
+  add_jammit_to_gemfile
 end

--- a/features/step_definitions/dependency_steps.rb
+++ b/features/step_definitions/dependency_steps.rb
@@ -1,3 +1,0 @@
-When /^I add "([^"]*)" from this project as a dependency$/ do |gem_name|
-  append_to_file('Gemfile', %{\ngem "#{gem_name}", :path => "#{PROJECT_ROOT}"})
-end

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -1,3 +1,7 @@
+After("@creates-remote") do
+  remove_all_created_remotes
+end
+
 When /^I create a Heroku remote named "([^"]*)"$/ do |remote_name|
   add_heroku_remote_named(remote_name)
 end
@@ -18,6 +22,17 @@ When /^I commit everything in the current repo$/ do
   end
 end
 
-After("@creates-remote") do
-  remove_all_created_remotes
+When /^I create an untracked file$/ do
+  write_file("untracked-file", "anything")
+end
+
+When /^I modify a tracked file$/ do
+  steps %{
+    Given I write to "new-file" with:
+      """
+      clean
+      """
+    And I commit everything in the current repo
+    When I append to "new-file" with "dirty it up"
+  }
 end

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -29,3 +29,7 @@ end
 When /^I add the origin remote$/ do
   add_origin_remote
 end
+
+When /^I switch to the "([^"]+)" branch$/ do |branch_name|
+  run_simple("git checkout -b #{branch_name}")
+end

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -29,3 +29,7 @@ end
 When /^I modify a tracked file$/ do
   modify_tracked_file
 end
+
+When /^I add the origin remote$/ do
+  add_origin_remote
+end

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -22,8 +22,10 @@ When /^I create an untracked file$/ do
   write_file("untracked-file", "anything")
 end
 
+Given /^a dirty repo$/ do
+  modify_tracked_file
+end
+
 When /^I modify a tracked file$/ do
-  write_file('tracked-file', 'clean')
-  commit_everything_in_repo
-  append_to_file('tracked-file', 'dirty it up')
+  modify_tracked_file
 end

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -1,7 +1,3 @@
-After("@creates-remote") do
-  remove_all_created_remotes
-end
-
 When /^I create a Heroku remote named "([^"]*)"$/ do |remote_name|
   add_heroku_remote_named(remote_name)
 end

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -11,15 +11,11 @@ When /^I create a non-Heroku remote named "([^"]*)"$/ do |remote_name|
 end
 
 When /^I set up a git repo$/ do
-  ["git init", "touch .gitkeep", "git add .", "git commit -am First"].each do |git_command|
-    run_simple(git_command)
-  end
+  set_up_git_repo
 end
 
 When /^I commit everything in the current repo$/ do
-  ['git add .', 'git commit -am MY_MESSAGE'].each do |git_command|
-    run_simple(git_command)
-  end
+  commit_everything_in_repo
 end
 
 When /^I create an untracked file$/ do
@@ -27,12 +23,7 @@ When /^I create an untracked file$/ do
 end
 
 When /^I modify a tracked file$/ do
-  steps %{
-    Given I write to "new-file" with:
-      """
-      clean
-      """
-    And I commit everything in the current repo
-    When I append to "new-file" with "dirty it up"
-  }
+  write_file('tracked-file', 'clean')
+  commit_everything_in_repo
+  append_to_file('tracked-file', 'dirty it up')
 end

--- a/features/step_definitions/jammit_steps.rb
+++ b/features/step_definitions/jammit_steps.rb
@@ -1,0 +1,3 @@
+When /^I set up Jammit$/ do
+  set_up_jammit
+end

--- a/features/step_definitions/kumade_steps.rb
+++ b/features/step_definitions/kumade_steps.rb
@@ -1,11 +1,5 @@
 When /^I run kumade with "([^"]+)"$/ do |args|
-  When %{I run `bundle exec kumade #{args}`}
-end
-
-Given /^I have loaded "([^"]+)"$/ do |file|
-  in_current_dir do
-    load(file)
-  end
+  run_simple("bundle exec kumade #{args}")
 end
 
 Given /^a directory set up for kumade$/ do

--- a/features/step_definitions/kumade_steps.rb
+++ b/features/step_definitions/kumade_steps.rb
@@ -1,9 +1,9 @@
 When /^I run kumade$/ do
-  run_simple("bundle exec kumade")
+  run_simple("bundle exec kumade", must_be_successful = false)
 end
 
 When /^I run kumade with "([^"]+)"$/ do |args|
-  run_simple("bundle exec kumade #{args}")
+  run_simple("bundle exec kumade #{args}", must_be_successful = false)
 end
 
 Given /^a directory set up for kumade$/ do

--- a/features/step_definitions/kumade_steps.rb
+++ b/features/step_definitions/kumade_steps.rb
@@ -1,3 +1,7 @@
+When /^I run kumade$/ do
+  run_simple("bundle exec kumade")
+end
+
 When /^I run kumade with "([^"]+)"$/ do |args|
   run_simple("bundle exec kumade #{args}")
 end

--- a/features/step_definitions/kumade_steps.rb
+++ b/features/step_definitions/kumade_steps.rb
@@ -7,3 +7,13 @@ Given /^I have loaded "([^"]+)"$/ do |file|
     load(file)
   end
 end
+
+Given /^a directory set up for kumade$/ do
+  steps %{
+    Given a directory named "the-kumade-directory"
+    When I cd to "the-kumade-directory"
+    And I set up the Gemfile with kumade
+    And I bundle
+    And I set up a git repo
+  }
+end

--- a/features/step_definitions/kumade_steps.rb
+++ b/features/step_definitions/kumade_steps.rb
@@ -7,11 +7,9 @@ When /^I run kumade with "([^"]+)"$/ do |args|
 end
 
 Given /^a directory set up for kumade$/ do
-  steps %{
-    Given a directory named "the-kumade-directory"
-    When I cd to "the-kumade-directory"
-    And I set up the Gemfile with kumade
-    And I bundle
-    And I set up a git repo
-  }
+  create_dir('the-kumade-directory')
+  cd('the-kumade-directory')
+  add_kumade_to_gemfile
+  run_bundler
+  set_up_git_repo
 end

--- a/features/step_definitions/rails_steps.rb
+++ b/features/step_definitions/rails_steps.rb
@@ -1,6 +1,14 @@
 Given /^a new Rails application with Kumade$/ do
-  run_simple("rails new rake-tasks")
+  run_simple("rails new rake-tasks -T")
   cd('rake-tasks')
   append_to_file('Gemfile', "gem 'kumade', :path => '#{PROJECT_PATH}'")
   run_bundler
+  set_up_git_repo
+end
+
+Given /^a new Rails application with Kumade and Jammit$/ do
+  Given "a new Rails application with Kumade"
+  add_jammit_to_gemfile
+  run_bundler
+  set_up_git_repo
 end

--- a/features/step_definitions/rails_steps.rb
+++ b/features/step_definitions/rails_steps.rb
@@ -7,7 +7,7 @@ Given /^a new Rails application with Kumade and Jammit$/ do
 end
 
 When /^I configure my Rails app for Jammit$/ do
-  run_bundler#_from_vendor
+  run_bundler
   set_up_jammit
   add_origin_remote
 end

--- a/features/step_definitions/rails_steps.rb
+++ b/features/step_definitions/rails_steps.rb
@@ -1,14 +1,7 @@
 Given /^a new Rails application with Kumade$/ do
-  run_simple("rails new rake-tasks -T")
-  cd('rake-tasks')
-  append_to_file('Gemfile', "gem 'kumade', :path => '#{PROJECT_PATH}'")
-  run_bundler
-  set_up_git_repo
+  create_rails_app_with_kumade
 end
 
 Given /^a new Rails application with Kumade and Jammit$/ do
-  Given "a new Rails application with Kumade"
-  add_jammit_to_gemfile
-  run_bundler
-  set_up_git_repo
+  create_rails_app_with_kumade_and_jammit
 end

--- a/features/step_definitions/rails_steps.rb
+++ b/features/step_definitions/rails_steps.rb
@@ -5,3 +5,9 @@ end
 Given /^a new Rails application with Kumade and Jammit$/ do
   create_rails_app_with_kumade_and_jammit
 end
+
+When /^I configure my Rails app for Jammit$/ do
+  run_bundler#_from_vendor
+  set_up_jammit
+  add_origin_remote
+end

--- a/features/step_definitions/rake_steps.rb
+++ b/features/step_definitions/rake_steps.rb
@@ -34,5 +34,5 @@ When /^I add a pre-compilation rake task that prints "Hi!"$/ do
       end
   CUSTOM_TASK
 
-  When "I commit everything in the current repo"
+  commit_everything_in_repo
 end

--- a/features/step_definitions/rake_steps.rb
+++ b/features/step_definitions/rake_steps.rb
@@ -24,3 +24,15 @@ Then /^the rake tasks should not include "([^"]+)"/ do |task_name|
     Then the output from "bundle exec rake -T" should not contain "#{task_name}"
   }
 end
+
+When /^I add a pre-compilation rake task that prints "Hi!"$/ do
+  append_to_file("Rakefile", <<-CUSTOM_TASK)
+      namespace :kumade do
+        task :before_asset_compilation do
+          puts 'Hi!'
+        end
+      end
+  CUSTOM_TASK
+
+  When "I commit everything in the current repo"
+end

--- a/features/support/bundler.rb
+++ b/features/support/bundler.rb
@@ -2,6 +2,14 @@ module BundlerHelpers
   def run_bundler
     run_simple('bundle --gemfile=./Gemfile --local || bundle --gemfile=./Gemfile')
   end
+
+  def add_jammit_to_gemfile
+    append_to_file('Gemfile', "\ngem 'jammit'")
+  end
+
+  def add_kumade_to_gemfile
+    append_to_file('Gemfile', "\ngem 'kumade', :path => '../../..'")
+  end
 end
 
 World(BundlerHelpers)

--- a/features/support/bundler.rb
+++ b/features/support/bundler.rb
@@ -1,6 +1,7 @@
 module BundlerHelpers
   def run_bundler
-    run_simple('bundle --gemfile=./Gemfile --local || bundle --gemfile=./Gemfile')
+    bundle = 'bundle install'
+    run_simple("#{bundle} --local || #{bundle}")
   end
 
   def add_jammit_to_gemfile

--- a/features/support/disable_bundler.rb
+++ b/features/support/disable_bundler.rb
@@ -1,0 +1,3 @@
+Before do
+  unset_bundler_env_vars
+end

--- a/features/support/git.rb
+++ b/features/support/git.rb
@@ -10,6 +10,12 @@ module GitHelpers
       run_simple(git_command)
     end
   end
+
+  def modify_tracked_file
+    write_file('tracked-file', 'clean')
+    commit_everything_in_repo
+    append_to_file('tracked-file', 'dirty it up')
+  end
 end
 
 World(GitHelpers)

--- a/features/support/git.rb
+++ b/features/support/git.rb
@@ -1,0 +1,15 @@
+module GitHelpers
+  def set_up_git_repo
+    ["git init", "touch .gitkeep", "git add .", "git commit -am First"].each do |git_command|
+      run_simple(git_command)
+    end
+  end
+
+  def commit_everything_in_repo
+    ['git add .', 'git commit -am MY_MESSAGE'].each do |git_command|
+      run_simple(git_command)
+    end
+  end
+end
+
+World(GitHelpers)

--- a/features/support/git.rb
+++ b/features/support/git.rb
@@ -5,15 +5,15 @@ module GitHelpers
     end
   end
 
-  def commit_everything_in_repo
-    ['git add .', 'git commit -am MY_MESSAGE'].each do |git_command|
+  def commit_everything_in_repo(message = "MY_MESSAGE")
+    ['git add .', "git commit -am '#{message}'"].each do |git_command|
       run_simple(git_command)
     end
   end
 
   def modify_tracked_file
     write_file('tracked-file', 'clean')
-    commit_everything_in_repo
+    commit_everything_in_repo('modify tracked file')
     append_to_file('tracked-file', 'dirty it up')
   end
 end

--- a/features/support/git_remotes.rb
+++ b/features/support/git_remotes.rb
@@ -20,6 +20,17 @@ module GitRemoteHelpers
     run_simple("git remote add #{remote_name} git@github.com:gabebw/kumade.git")
     @@created_remotes << remote_name
   end
+
+  def add_origin_remote
+    original_dir = current_dir
+    create_dir("../origin")
+    cd("../origin")
+    run_simple("git init --bare")
+
+    cd("../#{File.basename(original_dir)}")
+    run_simple("git remote add origin ../origin")
+    @@created_remotes << 'origin'
+  end
 end
 
 World(GitRemoteHelpers)

--- a/features/support/git_remotes.rb
+++ b/features/support/git_remotes.rb
@@ -34,3 +34,7 @@ module GitRemoteHelpers
 end
 
 World(GitRemoteHelpers)
+
+After do
+  remove_all_created_remotes
+end

--- a/features/support/jammit.rb
+++ b/features/support/jammit.rb
@@ -1,0 +1,14 @@
+module JammitHelpers
+  def set_up_jammit
+    assets_yaml = <<-YAML.strip
+      javascripts:
+        default:
+          - public/javascripts/application.js
+    YAML
+    write_file('public/javascripts/application.js', 'var foo = 3;')
+    write_file('config/assets.yml', assets_yaml)
+    commit_everything_in_repo('add Jammit files')
+  end
+end
+
+World(JammitHelpers)

--- a/features/support/rails.rb
+++ b/features/support/rails.rb
@@ -1,0 +1,18 @@
+module RailsAppHelpers
+  def create_rails_app_with_kumade
+    run_simple("rails new rake-tasks -T")
+    cd('rake-tasks')
+    append_to_file('Gemfile', "gem 'kumade', :path => '#{PROJECT_PATH}'")
+    run_bundler
+    set_up_git_repo
+  end
+
+  def create_rails_app_with_kumade_and_jammit
+    create_rails_app_with_kumade
+    add_jammit_to_gemfile
+    run_bundler
+    commit_everything_in_repo
+  end
+end
+
+World(RailsAppHelpers)

--- a/kumade.gemspec
+++ b/kumade.gemspec
@@ -19,13 +19,12 @@ Gem::Specification.new do |s|
   s.add_dependency('heroku', '~> 2.0')
   s.add_dependency('rake', '>= 0.8.7')
   s.add_dependency('cocaine', '>= 0.2.0')
+  s.add_dependency('rails', '>= 2')
 
-  s.add_development_dependency('rake', '>= 0.8.7')
   s.add_development_dependency('rspec', '~> 2.6.0')
   s.add_development_dependency('cucumber', '~> 1.0.2')
   s.add_development_dependency('aruba', '~> 0.4.3')
   s.add_development_dependency('jammit', '~> 0.6.3')
-  s.add_development_dependency('less', '~> 2.0')
   s.add_development_dependency('bourne')
   if RUBY_VERSION >= '1.9.0'
     s.add_development_dependency('simplecov')

--- a/lib/kumade/git.rb
+++ b/lib/kumade/git.rb
@@ -11,6 +11,7 @@ module Kumade
     end
 
     def push(branch, remote = 'origin', force = false)
+      return unless remote_exists?(remote)
       command = ["git push"]
       command << "-f" if force
       command << remote

--- a/lib/kumade/git.rb
+++ b/lib/kumade/git.rb
@@ -68,6 +68,12 @@ module Kumade
       end
     end
 
+    def has_untracked_files_in?(directory)
+      relative_dir = directory.sub(Dir.pwd + '/', '')
+      untracked_output = CommandLine.new("git status --porcelain --untracked-files").run
+      untracked_output.split("\n").grep(/^\?{2} #{relative_dir}/).size > 0
+    end
+
     private
 
     def has_branch?(branch)

--- a/lib/kumade/packager.rb
+++ b/lib/kumade/packager.rb
@@ -25,7 +25,7 @@ module Kumade
 
       begin
         @packager.package
-        if @git.dirty?
+        if @git.dirty? || @git.has_untracked_files_in?(@packager.assets_path)
           @git.add_and_commit_all_assets_in(@packager.assets_path)
           Kumade.configuration.outputter.success(success_message)
         end

--- a/lib/kumade/packager.rb
+++ b/lib/kumade/packager.rb
@@ -21,7 +21,7 @@ module Kumade
     end
 
     def package
-      return Kumade.configuration.outputter.success(success_message) if Kumade.configuration.pretending?
+      return Kumade.configuration.outputter.success(success_message) if Kumade.configuration.pretending? || @packager == NoopPackager
 
       begin
         @packager.package

--- a/lib/kumade/packager.rb
+++ b/lib/kumade/packager.rb
@@ -6,8 +6,10 @@ module Kumade
     end
 
     def run
-      precompile_assets
-      package
+      if @packager.installed?
+        precompile_assets
+        package
+      end
     end
 
     def self.available_packager
@@ -21,7 +23,7 @@ module Kumade
     end
 
     def package
-      return Kumade.configuration.outputter.success(success_message) if Kumade.configuration.pretending? || @packager == NoopPackager
+      return Kumade.configuration.outputter.success(success_message) if Kumade.configuration.pretending?
 
       begin
         @packager.package

--- a/spec/kumade/git_spec.rb
+++ b/spec/kumade/git_spec.rb
@@ -43,27 +43,42 @@ end
 describe Kumade::Git, "#push", :with_mock_outputter do
   let(:branch)       { 'branch' }
   let(:remote)       { 'my-remote' }
-  let(:command_line) { stub("Kumade::CommandLine instance", :run_or_error => true) }
 
-  before do
-    Kumade::CommandLine.stubs(:new => command_line)
+  context "when the remote exists" do
+    let(:command_line) { stub("Kumade::CommandLine instance", :run_or_error => true) }
+
+    before do
+      Kumade::CommandLine.stubs(:new => command_line)
+      subject.stubs(:remote_exists? => true)
+    end
+
+    it "pushes to the correct remote" do
+      subject.push(branch, remote)
+      Kumade::CommandLine.should have_received(:new).with("git push #{remote} #{branch}")
+      command_line.should have_received(:run_or_error).once
+    end
+
+    it "can force push" do
+      subject.push(branch, remote, true)
+      Kumade::CommandLine.should have_received(:new).with("git push -f #{remote} #{branch}")
+      command_line.should have_received(:run_or_error).once
+    end
+
+    it "prints a success message" do
+      subject.push(branch, remote)
+      Kumade.configuration.outputter.should have_received(:success).with("Pushed #{branch} -> #{remote}")
+    end
   end
 
-  it "pushes to the correct remote" do
-    subject.push(branch, remote)
-    Kumade::CommandLine.should have_received(:new).with("git push #{remote} #{branch}")
-    command_line.should have_received(:run_or_error).once
-  end
-
-  it "can force push" do
-    subject.push(branch, remote, true)
-    Kumade::CommandLine.should have_received(:new).with("git push -f #{remote} #{branch}")
-    command_line.should have_received(:run_or_error).once
-  end
-
-  it "prints a success message" do
-    subject.push(branch, remote)
-    Kumade.configuration.outputter.should have_received(:success).with("Pushed #{branch} -> #{remote}")
+  context "when the remote does not exist" do
+    before do
+      subject.stubs(:remote_exists? => false)
+    end
+    
+    it "returns silently" do
+      subject.push(branch)
+      Kumade::CommandLine.should have_received(:new).never
+    end
   end
 end
 

--- a/spec/kumade/git_spec.rb
+++ b/spec/kumade/git_spec.rb
@@ -227,3 +227,27 @@ describe Kumade::Git, "#ensure_clean_git", :with_mock_outputter do
     end
   end
 end
+
+describe Kumade::Git, "#has_untracked_files_in?", :with_mock_outputter do
+  let(:untracked_dir) { 'untracked' }
+
+  context "in normal mode" do
+    before do
+      Kumade.configuration.pretending = false
+      create_untracked_file_in(untracked_dir)
+    end
+
+    it "detects untracked files" do
+      subject.should have_untracked_files_in(untracked_dir)
+    end
+
+    it "detects untracked files when given an absolute path" do
+      subject.should have_untracked_files_in(File.expand_path("./" + untracked_dir))
+    end
+
+    it "does not get confused by tracked files" do
+      `git add . && git commit -am Message`
+      subject.should_not have_untracked_files_in(untracked_dir)
+    end
+  end
+end

--- a/spec/kumade/packager_spec.rb
+++ b/spec/kumade/packager_spec.rb
@@ -9,7 +9,7 @@ describe Kumade::Packager, ".available_packager", :with_mock_outputter do
     Kumade::Packager.available_packager.should == packager_1
   end
 
-  it "returns nil if no packagers are availabke" do
+  it "returns nil if no packagers are available" do
     Kumade::PackagerList.stubs(:new => [])
     Kumade::Packager.available_packager.should be_nil
   end
@@ -17,7 +17,7 @@ end
 
 describe Kumade::Packager, "#run", :with_mock_outputter do
   let(:git)              { stub("git", :dirty? => true, :add_and_commit_all_assets_in => true) }
-  let(:packager)         { stub("packager", :name => "MyPackager", :package => true, :assets_path => 'fake_assets_path') }
+  let(:packager)         { stub("packager", :name => "MyPackager", :package => true, :assets_path => 'fake_assets_path', :installed? => true) }
   let(:rake_task_runner) { stub("RakeTaskRunner", :invoke => true) }
 
   before do

--- a/spec/support/git.rb
+++ b/spec/support/git.rb
@@ -2,4 +2,9 @@ module GitHelpers
   def dirty_the_repo
     `echo dirty_it_up > .gitkeep`
   end
+
+  def create_untracked_file_in(directory)
+    FileUtils.mkdir_p(directory)
+    FileUtils.touch(File.join(directory, 'i-am-untracked'))
+  end
 end


### PR DESCRIPTION
Allows kumade to work without an 'origin' remote.

Closes #65

This branch is newly created from todays HEAD.  This was trivial to do after you cleaned up the specs and scenarios ... thank you!
