### PR TITLE
Git#push when remote does not exist returns silently

### DIFF
--- a/lib/kumade/git.rb
+++ b/lib/kumade/git.rb
@@ -11,6 +11,7 @@ module Kumade
     end
 
     def push(branch, remote = 'origin', force = false)
+      return unless remote_exists?(remote)
       command = ["git push"]
       command << "-f" if force
       command << remote

--- a/spec/kumade/git_spec.rb
+++ b/spec/kumade/git_spec.rb
@@ -43,27 +43,42 @@ end
 describe Kumade::Git, "#push", :with_mock_outputter do
   let(:branch)       { 'branch' }
   let(:remote)       { 'my-remote' }
-  let(:command_line) { stub("Kumade::CommandLine instance", :run_or_error => true) }
 
-  before do
-    Kumade::CommandLine.stubs(:new => command_line)
+  context "when the remote exists" do
+    let(:command_line) { stub("Kumade::CommandLine instance", :run_or_error => true) }
+
+    before do
+      Kumade::CommandLine.stubs(:new => command_line)
+      subject.stubs(:remote_exists? => true)
+    end
+
+    it "pushes to the correct remote" do
+      subject.push(branch, remote)
+      Kumade::CommandLine.should have_received(:new).with("git push #{remote} #{branch}")
+      command_line.should have_received(:run_or_error).once
+    end
+
+    it "can force push" do
+      subject.push(branch, remote, true)
+      Kumade::CommandLine.should have_received(:new).with("git push -f #{remote} #{branch}")
+      command_line.should have_received(:run_or_error).once
+    end
+
+    it "prints a success message" do
+      subject.push(branch, remote)
+      Kumade.configuration.outputter.should have_received(:success).with("Pushed #{branch} -> #{remote}")
+    end
   end
 
-  it "pushes to the correct remote" do
-    subject.push(branch, remote)
-    Kumade::CommandLine.should have_received(:new).with("git push #{remote} #{branch}")
-    command_line.should have_received(:run_or_error).once
-  end
-
-  it "can force push" do
-    subject.push(branch, remote, true)
-    Kumade::CommandLine.should have_received(:new).with("git push -f #{remote} #{branch}")
-    command_line.should have_received(:run_or_error).once
-  end
-
-  it "prints a success message" do
-    subject.push(branch, remote)
-    Kumade.configuration.outputter.should have_received(:success).with("Pushed #{branch} -> #{remote}")
+  context "when the remote does not exist" do
+    before do
+      subject.stubs(:remote_exists? => false)
+    end
+    
+    it "returns silently" do
+      subject.push(branch)
+      Kumade::CommandLine.should have_received(:new).never
+    end
   end
 end
 


### PR DESCRIPTION
Allows kumade to work without an 'origin' remote.

Closes #65

This branch is newly created from todays HEAD.
