### PR TITLE
Fixes public root bug with Jammit 0.6.5

### DIFF
--- a/lib/kumade/packagers/jammit_packager.rb
+++ b/lib/kumade/packagers/jammit_packager.rb
@@ -6,7 +6,7 @@ end
 module Kumade
   class JammitPackager
     def self.assets_path
-      File.join(Jammit::PUBLIC_ROOT, Jammit.package_path)
+      File.join(public_root, Jammit.package_path)
     end
 
     def self.installed?
@@ -15,6 +15,12 @@ module Kumade
 
     def self.package
       Jammit.package!
+    end
+
+    private
+
+    def self.public_root
+      defined?(Jammit.public_root) ? Jammit.public_root : Jammit::PUBLIC_ROOT
     end
   end
 end

--- a/spec/kumade/packagers/jammit_packager_spec.rb
+++ b/spec/kumade/packagers/jammit_packager_spec.rb
@@ -7,7 +7,8 @@ describe Kumade::JammitPackager, :with_mock_outputter do
 
   it_should_behave_like "packager"
 
-  its(:assets_path) { should == File.join(Jammit::PUBLIC_ROOT, Jammit.package_path) }
+  let(:jammit_public_root) { defined?(Jammit.public_root) ? Jammit.public_root : Jammit::PUBLIC_ROOT }
+  its(:assets_path) { should == File.join(jammit_public_root, Jammit.package_path) }
 
   it "knows how to package itself" do
     ::Jammit.stubs(:package!)


### PR DESCRIPTION
The way Jammit defines the public root was changed in
https://github.com/documentcloud/jammit/commit/b6ff4f0d63ddf615874dc9ad023924e94a8e2da1

This patch handles both the new and old implementation.
