### PR TITLE
Get to green

### DIFF
--- a/kumade.gemspec
+++ b/kumade.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 2.6.0')
   s.add_development_dependency('cucumber', '~> 1.0.2')
   s.add_development_dependency('aruba', '~> 0.4.3')
-  s.add_development_dependency('jammit', '~> 0.6.3')
+  s.add_development_dependency('jammit', '~> 0.6.4')
   s.add_development_dependency('bourne')
   if RUBY_VERSION >= '1.9.0'
     s.add_development_dependency('simplecov')

--- a/lib/kumade/packagers/jammit_packager.rb
+++ b/lib/kumade/packagers/jammit_packager.rb
@@ -6,7 +6,7 @@ end
 module Kumade
   class JammitPackager
     def self.assets_path
-      File.join(Jammit::PUBLIC_ROOT, Jammit.package_path)
+      File.join(Jammit::DEFAULT_PUBLIC_ROOT, Jammit.package_path)
     end
 
     def self.installed?

--- a/spec/kumade/packagers/jammit_packager_spec.rb
+++ b/spec/kumade/packagers/jammit_packager_spec.rb
@@ -7,7 +7,7 @@ describe Kumade::JammitPackager, :with_mock_outputter do
 
   it_should_behave_like "packager"
 
-  its(:assets_path) { should == File.join(Jammit::PUBLIC_ROOT, Jammit.package_path) }
+  its(:assets_path) { should == File.join(Jammit::DEFAULT_PUBLIC_ROOT, Jammit.package_path) }
 
   it "knows how to package itself" do
     ::Jammit.stubs(:package!)


### PR DESCRIPTION
Fixed the failing specs, caused by Jammit renaming `Jammit::PUBLIC_ROOT` to `Jammit::DEFAULT_PUBLIC_ROOT`.
